### PR TITLE
Changed package name, updated sqlglot dependency, added update_chart

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 # https://setuptools.pypa.io/en/latest/references/keywords.html
 
 [metadata]
-name = preset-cli
+name = preset-cli-a8c
 description = A CLI to interact with Preset (https://preset.io/) workspaces.
 author = Beto Dealmeida
 author_email = beto@preset.io
@@ -71,7 +71,7 @@ install_requires =
     requests>=2.26.0
     rich>=12.3.0
     sqlalchemy>=1.4,<2
-    sqlglot>=23.0.2,<24
+    sqlglot>=23.0.2
     tabulate>=0.8.9
     typing-extensions>=4.0.1
     yarl>=1.7.2

--- a/src/preset_cli/api/clients/superset.py
+++ b/src/preset_cli/api/clients/superset.py
@@ -671,6 +671,12 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
         """
         return self.get_resources("chart", **kwargs)
 
+    def update_chart(self, chart_id: int, **kwargs: Any) -> Any:
+        """
+        Update a chart.
+        """
+        return self.update_resource("chart", chart_id, **kwargs)
+
     def get_dashboard(self, dashboard_id: int) -> Any:
         """
         Return a single dashboard.


### PR DESCRIPTION
A few changes:
- changed package name to preset-cli-a8c so that we can build and publish it to pypi, since git references are not supported in our python-project distributions
- removed upper version limit for sqlglot as it was leading to a conflict with superset 4.1.0. This limit was added because of an [incompatibility](https://github.com/preset-io/backend-sdk/pull/283). This issue however affects metric retrieval which we are not using. This is a sad workaround and we should remove it once preset-cli updates its code. 
- added update_chart method