### PR TITLE
Bump sqlglot to same version used in latest superset version

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -67,7 +67,7 @@ rich==12.5.1
 six==1.16.0
 soupsieve==2.3.2.post1
 sqlalchemy==1.4.40
-sqlglot==20.7.1
+sqlglot==25.24.5
 tabulate==0.8.10
 toml==0.10.2
 tomli==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ rich==12.3.0
 six==1.16.0
 soupsieve==2.3.2.post1
 sqlalchemy==1.4.35
-sqlglot==20.7.1
+sqlglot==25.24.5
 tabulate==0.8.9
 typing-extensions==4.2.0
 urllib3==1.26.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,8 @@ package_dir =
 # Version specifiers like >=2.2,<3.0 avoid problems due to API changes in
 # new major versions. This works if the required packages follow Semantic Versioning.
 # For more information, check out https://semver.org/.
+
+# Setting sqlglot to the same version used in the latest superset
 install_requires =
     importlib-metadata; python_version<"3.8"
     Cython>=0.29.26
@@ -71,7 +73,7 @@ install_requires =
     requests>=2.26.0
     rich>=12.3.0
     sqlalchemy>=1.4,<2
-    sqlglot>=23.0.2,<24
+    sqlglot==25.24.5
     tabulate>=0.8.9
     typing-extensions>=4.0.1
     yarl>=1.7.2

--- a/src/preset_cli/cli/superset/sync/dbt/metrics.py
+++ b/src/preset_cli/cli/superset/sync/dbt/metrics.py
@@ -300,8 +300,8 @@ def convert_query_to_projection(sql: str, dialect: MFSQLEngine) -> str:
     )
 
     # replace aliases with their original expressions
-    for node, _, _ in metric_expression.walk():
-        if isinstance(node, Identifier) and node.sql() in aliases:
+    for node in metric_expression.find_all(Identifier):
+        if node.sql() in aliases:
             node.replace(parse_one(aliases[node.sql()]))
 
     # convert WHERE predicate to a CASE statement
@@ -310,13 +310,12 @@ def convert_query_to_projection(sql: str, dialect: MFSQLEngine) -> str:
 
         # Remove DISTINCT from metric to avoid conficting with CASE
         distinct = False
-        for node, _, _ in metric_expression.this.walk():
-            if isinstance(node, Distinct):
-                distinct = True
-                node.replace(node.expressions[0])
+        for node in metric_expression.find_all(Distinct):
+            distinct = True
+            node.replace(node.expressions[0])
 
-        for node, _, _ in where_expression.walk():
-            if isinstance(node, Identifier) and node.sql() in aliases:
+        for node in where_expression.find_all(Identifier):
+            if node.sql() in aliases:
                 node.replace(parse_one(aliases[node.sql()]))
 
         case_expression = Case(

--- a/src/preset_cli/cli/superset/sync/dbt/metrics.py
+++ b/src/preset_cli/cli/superset/sync/dbt/metrics.py
@@ -122,6 +122,16 @@ def get_metric_expression(metric_name: str, metrics: Dict[str, OGMetricSchema]) 
     raise Exception(f"Unable to generate metric expression from: {sorted_metric}")
 
 
+def merge_tokens(token1: Token, token2: Token, token_type: TokenType) -> Token:
+    """
+    Merge two tokens
+    """
+    merged_token = token1
+    merged_token.text += token2.text
+    merged_token.token_type = token_type
+    return merged_token
+
+
 def replace_jinja_tokens(tokens: List[Token]) -> List[Token]:
     """
     Replaces Jinja-style `{{` and `}}` as block start/end.
@@ -130,11 +140,6 @@ def replace_jinja_tokens(tokens: List[Token]) -> List[Token]:
     Returns:
         List[Token]: List of tokens with Jinja blocks replaced.
     """
-    def merge_tokens(i: int, token_type: TokenType) -> Token:
-        token = tokens[i]
-        token.text += tokens[i + 1].text
-        token.token_type = token_type
-        return token
 
     merged_tokens = []
     i = 0
@@ -142,11 +147,11 @@ def replace_jinja_tokens(tokens: List[Token]) -> List[Token]:
     while i < len(tokens):
         if i < len(tokens) - 1:
             if tokens[i].token_type == TokenType.L_BRACE and tokens[i + 1].token_type == TokenType.L_BRACE:
-                merged_tokens.append(merge_tokens(i, TokenType.BLOCK_START))
+                merged_tokens.append(merge_tokens(tokens[i], tokens[i + 1], TokenType.BLOCK_START))
                 i += 2
                 continue
             elif tokens[i].token_type == TokenType.R_BRACE and tokens[i + 1].token_type == TokenType.R_BRACE:
-                merged_tokens.append(merge_tokens(i, TokenType.BLOCK_END))
+                merged_tokens.append(merge_tokens(tokens[i], tokens[i + 1], TokenType.BLOCK_END))
                 i += 2
                 continue
 

--- a/src/preset_cli/cli/superset/sync/dbt/metrics.py
+++ b/src/preset_cli/cli/superset/sync/dbt/metrics.py
@@ -125,30 +125,28 @@ def get_metric_expression(metric_name: str, metrics: Dict[str, OGMetricSchema]) 
 def replace_jinja_tokens(tokens: List[Token]) -> List[Token]:
     """
     Replaces Jinja-style `{{` and `}}` as block start/end.
-
     Args:
         tokens (List[Token]): List of tokens to process.
-
     Returns:
         List[Token]: List of tokens with Jinja blocks replaced.
     """
+    def merge_tokens(i: int, token_type: TokenType) -> Token:
+        token = tokens[i]
+        token.text += tokens[i + 1].text
+        token.token_type = token_type
+        return token
+
     merged_tokens = []
     i = 0
 
     while i < len(tokens):
         if i < len(tokens) - 1:
             if tokens[i].token_type == TokenType.L_BRACE and tokens[i + 1].token_type == TokenType.L_BRACE:
-                block_start = tokens[i]
-                block_start.text += tokens[i + 1].text
-                block_start.token_type = TokenType.BLOCK_START
-                merged_tokens.append(block_start)
+                merged_tokens.append(merge_tokens(i, TokenType.BLOCK_START))
                 i += 2
                 continue
             if tokens[i].token_type == TokenType.R_BRACE and tokens[i + 1].token_type == TokenType.R_BRACE:
-                block_end = tokens[i]
-                block_end.text += tokens[i + 1].text
-                block_end.token_type = TokenType.BLOCK_END
-                merged_tokens.append(block_end)
+                merged_tokens.append(merge_tokens(i, TokenType.BLOCK_END))
                 i += 2
                 continue
 

--- a/src/preset_cli/cli/superset/sync/dbt/metrics.py
+++ b/src/preset_cli/cli/superset/sync/dbt/metrics.py
@@ -10,7 +10,6 @@ import json
 import logging
 import re
 from collections import defaultdict
-from copy import deepcopy
 
 from sqlglot.tokens import Token
 from typing import Dict, List, Optional, Set

--- a/src/preset_cli/cli/superset/sync/dbt/metrics.py
+++ b/src/preset_cli/cli/superset/sync/dbt/metrics.py
@@ -145,7 +145,7 @@ def replace_jinja_tokens(tokens: List[Token]) -> List[Token]:
                 merged_tokens.append(merge_tokens(i, TokenType.BLOCK_START))
                 i += 2
                 continue
-            if tokens[i].token_type == TokenType.R_BRACE and tokens[i + 1].token_type == TokenType.R_BRACE:
+            elif tokens[i].token_type == TokenType.R_BRACE and tokens[i + 1].token_type == TokenType.R_BRACE:
                 merged_tokens.append(merge_tokens(i, TokenType.BLOCK_END))
                 i += 2
                 continue

--- a/tests/cli/superset/sync/dbt/metrics_test.py
+++ b/tests/cli/superset/sync/dbt/metrics_test.py
@@ -1251,6 +1251,7 @@ def test_replace_metric_syntax() -> None:
             },
         ),
     }
+
     result = replace_metric_syntax(sql, ["revenue", "cost"], metrics)
     assert (
         result


### PR DESCRIPTION
There is also a bug in `sqlglot `that doesn't recognize `{{` .. `}}` as a jinja block. So this PR includes a fix to replace the token for dbt expression with the correct one and fix all tests after upgrading the sqlglot version.

- Reference
https://github.com/tobymao/sqlglot/issues/1713